### PR TITLE
fix: add codiceIPA to publiccode.yml file

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -160,6 +160,8 @@ intendedAudience:
   scope:
     - government
 it:
+  riuso:
+    codiceIPA: c_a662
   conforme:
     gdpr: false
     lineeGuidaDesign: false


### PR DESCRIPTION
Buongiorno @comunedibari,

questa PR aggiunge il codiceIPA del comune al file publiccode.yml per permettere una corretta indicizzazione.

A presto