### PR TITLE
Fix: moved absolute links to relative ones

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -91,19 +91,13 @@ description:
 
             - Gestione del catalogo e dei metadati.
     screenshots:
-      - |-
-        https://raw.githubusercontent.com/comunedibari/SIT/master/img/Home-comuni.jpg
-      - |-
-        https://raw.githubusercontent.com/comunedibari/SIT/master/img/app-verdepubblico.jpg
-      - |-
-        https://raw.githubusercontent.com/comunedibari/SIT/master/img/editing.jpg
-      - |-
-        https://raw.githubusercontent.com/comunedibari/SIT/master/img/identify.jpg
-      - |-
-        https://raw.githubusercontent.com/comunedibari/SIT/master/img/Legenda.jpg
-      - |-
-        https://raw.githubusercontent.com/comunedibari/SIT/master/img/streetview.jpg
-      - 'https://raw.githubusercontent.com/comunedibari/SIT/master/img/toc.jpg'
+      - img/Home-comuni.jpg
+      - img/app-verdepubblico.jpg
+      - img/editing.jpg
+      - img/identify.jpg
+      - img/Legenda.jpg
+      - img/streetview.jpg
+      - img/toc.jpg
     shortDescription: |-
       Kit di riuso a disposizione delle PA per la gestione e la pubblicazione
       di       mappe cartografiche e strumenti urbanistici.


### PR DESCRIPTION
Buongiorno @comunedibari,

questa PR:
* cambia gli URL da assoluti a relativi ad un path nel repo

Questo permette di risolvere il problema: 
```
description/it/screenshots: Absolute URL (https://raw.githubusercontent.com/comunedibari/SIT/master/img/Home-comuni.jpg) is outside the repository (https://raw.githubusercontent.com/comunedibari/SIT/main/)
```

A disposizione, grazie